### PR TITLE
refactor: improvements & add cliff-jumper

### DIFF
--- a/.cliff-jumperrc.json
+++ b/.cliff-jumperrc.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "./node_modules/@favware/cliff-jumper/assets/cliff-jumper.schema.json",
+  "name": "discord-prompts.js",
+  "org": "hidden-devs",
+  "monoRepo": false,
+  "packagePath": ".",
+  "commitMessageTemplate": "chore(release): release {{new-version}}",
+  "tagTemplate": "v{{new-version}}"
+}

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,63 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.\n
+"""
+body = """
+{% if version %}\
+    # [{{ version | trim_start_matches(pat="v") }}]\
+    {% if previous %}\
+        {% if previous.version %}\
+            (https://github.com/HiddenDevs/discord-prompts.js/compare/{{ previous.version }}...{{ version }})\
+        {% else %}\
+            (https://github.com/HiddenDevs/discord-prompts.js/tree/{{ version }})\
+        {% endif %}\
+    {% endif %} \
+    - ({{ timestamp | date(format="%Y-%m-%d") }})
+{% else %}\
+    # [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ## {{ group | upper_first }}
+    {% for commit in commits %}
+		- {% if commit.scope %}\
+			**{{commit.scope}}:** \
+		  {% endif %}\
+            {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/HiddenDevs/discord-prompts.js/commit/{{ commit.id }}))\
+		{% if commit.breaking %}\
+			{% for breakingChange in commit.footers %}\
+				\n{% raw %}  {% endraw %}- 💥 **{{ breakingChange.token }}{{ breakingChange.separator }}** {{ breakingChange.value }}\
+			{% endfor %}\
+		{% endif %}\
+    {% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+commit_parsers = [
+    { message = "^feat", group = "Features"},
+    { message = "^fix", group = "Bug Fixes"},
+    { message = "^docs", group = "Documentation"},
+    { message = "^perf", group = "Performance"},
+    { message = "^refactor", group = "Refactor"},
+    { message = "^typings", group = "Typings"},
+    { message = "^types", group = "Typings"},
+    { message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
+    { message = "^revert", skip = true},
+    { message = "^style", group = "Styling"},
+    { message = "^test", group = "Testing"},
+    { message = "^chore", skip = true},
+    { message = "^ci", skip = true},
+    { message = "^build", skip = true},
+    { body = ".*security", group = "Security"},
+]
+filter_commits = true
+tag_pattern = "@hidden-devs/discord-prompts.js@[0-9]*"
+ignore_tags = ""
+topo_order = false
+sort_commits = "newest"

--- a/examples/simple-go-back/commands/simple-command/index.ts
+++ b/examples/simple-go-back/commands/simple-command/index.ts
@@ -1,8 +1,8 @@
 import { ChatInputCommandInteraction } from 'discord.js';
-import { PromptContext } from './types/PromptContext';
 import { Prompt } from '../../../../src';
-import { initialState } from './states/initial-state';
 import { fakeErrorState } from './states/fake-error-state';
+import { initialState } from './states/initial-state';
+import { PromptContext } from './types/PromptContext';
 
 export const simpleCommand = {
 	name: 'simple',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
-  "name": "discord-prompts.js",
+  "name": "@hidden-devs/discord-prompts.js",
   "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "discord-prompts.js",
+      "name": "@hidden-devs/discord-prompts.js",
       "version": "1.2.1",
+      "license": "ISC",
       "dependencies": {
         "discord.js": "^14.14.1"
       },
       "devDependencies": {
+        "@favware/cliff-jumper": "^2.2.3",
         "@typescript-eslint/eslint-plugin": "^6.12.0",
         "@typescript-eslint/parser": "^6.12.0",
         "eslint": "^8.54.0",
@@ -190,6 +192,30 @@
         "node": ">=14"
       }
     },
+    "node_modules/@favware/cliff-jumper": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@favware/cliff-jumper/-/cliff-jumper-2.2.3.tgz",
+      "integrity": "sha512-UQ2ZLv69IVVt28+MXsy/iwUwtdqBx7LX2tOju/ECrljIxS+5jIEMTQVcWebfKK0dovMO68bCEr/3jlqBRVmoiw==",
+      "dev": true,
+      "dependencies": {
+        "@sapphire/result": "^2.6.4",
+        "@sapphire/utilities": "3.13.0",
+        "colorette": "^2.0.20",
+        "commander": "^11.1.0",
+        "compare-func": "^2.0.0",
+        "conventional-recommended-bump": "^9.0.0",
+        "git-cliff": "^1.4.0",
+        "js-yaml": "^4.1.0",
+        "semver": "^7.5.4"
+      },
+      "bin": {
+        "cj": "dist/cli.js",
+        "cliff-jumper": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
@@ -287,6 +313,16 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@sapphire/result": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/result/-/result-2.6.5.tgz",
+      "integrity": "sha512-bpvrUEchle+kekLdZsBj2i3zm/KzSjHn+cndDSpGIbq6fbxS5zbMoxfh3c3afOq6mx07fJL0sv7GCfqARoQg1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@sapphire/shapeshift": {
       "version": "3.9.3",
       "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.3.tgz",
@@ -304,6 +340,16 @@
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
       "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/utilities": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/utilities/-/utilities-3.13.0.tgz",
+      "integrity": "sha512-BD5ycPjZX5dXxrAb90dJTY8ukpPVBXgU17gA5ghK2memS4hwAzFYpvK+R+6zh4d6HYIKVuqrVhGXjvZenAa/Aw==",
+      "dev": true,
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -608,6 +654,12 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "dev": true
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -724,11 +776,92 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/conventional-changelog-preset-loader": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-4.1.0.tgz",
+      "integrity": "sha512-HozQjJicZTuRhCRTq4rZbefaiCzRM2pr6u2NL3XhrmQm4RMnDXfESU6JKu/pnKwx5xtdkYfNCsbhN5exhiKGJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/conventional-commits-filter": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
+      "integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
+      "integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
+      "dev": true,
+      "dependencies": {
+        "is-text-path": "^2.0.0",
+        "JSONStream": "^1.3.5",
+        "meow": "^12.0.1",
+        "split2": "^4.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "cli.mjs"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/conventional-recommended-bump": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-9.0.0.tgz",
+      "integrity": "sha512-HR1yD0G5HgYAu6K0wJjLd7QGRK8MQDqqj6Tn1n/ja1dFwBCE6QmV+iSgQ5F7hkx7OUR/8bHpxJqYtXj2f/opPQ==",
+      "dev": true,
+      "dependencies": {
+        "conventional-changelog-preset-loader": "^4.1.0",
+        "conventional-commits-filter": "^4.0.0",
+        "conventional-commits-parser": "^5.0.0",
+        "git-raw-commits": "^4.0.0",
+        "git-semver-tags": "^7.0.0",
+        "meow": "^12.0.1"
+      },
+      "bin": {
+        "conventional-recommended-bump": "cli.mjs"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -742,6 +875,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/dargs": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
+      "integrity": "sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/debug": {
@@ -864,6 +1009,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1210,6 +1367,134 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/git-cliff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/git-cliff/-/git-cliff-1.4.0.tgz",
+      "integrity": "sha512-BLHYp/BD5jfOoPA3B6Ht1s1rJxtPcpmgyjQFZSFP53AdjVyfI2kwk7aVmxEfd1RQsBHRBVfPyJ+PNVghsfo3Yg==",
+      "dev": true,
+      "bin": {
+        "git-cliff": "lib/index.js"
+      },
+      "optionalDependencies": {
+        "git-cliff-darwin-arm64": "1.4.0",
+        "git-cliff-darwin-x64": "1.4.0",
+        "git-cliff-linux-arm64": "1.4.0",
+        "git-cliff-linux-x64": "1.4.0",
+        "git-cliff-windows-arm64": "1.4.0",
+        "git-cliff-windows-x64": "1.4.0"
+      }
+    },
+    "node_modules/git-cliff-darwin-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/git-cliff-darwin-arm64/-/git-cliff-darwin-arm64-1.4.0.tgz",
+      "integrity": "sha512-QCCvi+gIP+2KXWBzCccIDF2GCNbpm9RND7HbDmU79uKP9Qp070ZSYxlqifph6bUxFFw7dRwlVHiKxyUADwnxSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/git-cliff-darwin-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/git-cliff-darwin-x64/-/git-cliff-darwin-x64-1.4.0.tgz",
+      "integrity": "sha512-9b+y3vC4J4G3X9ndNj0s8YiKV1IBux7yU5mDMZhcUA7g9gveoPo+eZZLyPl6+KHxoOE7GCgfHFIhhC+zwh/oWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/git-cliff-linux-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/git-cliff-linux-arm64/-/git-cliff-linux-arm64-1.4.0.tgz",
+      "integrity": "sha512-caUW7eIkAXZKjzFgQKMlFia+9zkgjPPtnzXeZwkXjtDaSACbzqss+AvaxZUEVy+xfj14+RHOFTn6WCpQJ1NbGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/git-cliff-linux-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/git-cliff-linux-x64/-/git-cliff-linux-x64-1.4.0.tgz",
+      "integrity": "sha512-9HNuziC2ZsM1z1xrq+pRfFiH3LSdEwK1QyW/vngJP/f4GlO5Zm3tBX4n7Y+8yLUcyYMezKsR+rPF9MRmIswpgQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/git-cliff-windows-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/git-cliff-windows-arm64/-/git-cliff-windows-arm64-1.4.0.tgz",
+      "integrity": "sha512-J0E/74+xowQfuLHHIB3KP6eFp+V39nhPVuAgNLnrLY28Yvqn8AGKCidQStisfjMS2Ot/a7yKFv1JwW/bR0lQjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/git-cliff-windows-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/git-cliff-windows-x64/-/git-cliff-windows-x64-1.4.0.tgz",
+      "integrity": "sha512-w/mOm00QEuu4VPkmJsyaSlaJtjo6kgvb9v7n81eZSj3SnpTRQzNXTjB1JzKavgqnJ6JnAQiypRmPwC1FsCyiFA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/git-raw-commits": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-4.0.0.tgz",
+      "integrity": "sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==",
+      "dev": true,
+      "dependencies": {
+        "dargs": "^8.0.0",
+        "meow": "^12.0.1",
+        "split2": "^4.0.0"
+      },
+      "bin": {
+        "git-raw-commits": "cli.mjs"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/git-semver-tags": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-7.0.1.tgz",
+      "integrity": "sha512-NY0ZHjJzyyNXHTDZmj+GG7PyuAKtMsyWSwh07CR2hOZFa+/yoTsXci/nF2obzL8UDhakFNkD9gNdt/Ed+cxh2Q==",
+      "dev": true,
+      "dependencies": {
+        "meow": "^12.0.1",
+        "semver": "^7.5.2"
+      },
+      "bin": {
+        "git-semver-tags": "cli.mjs"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -1414,6 +1699,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -1433,6 +1727,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-text-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
+      "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
+      "dev": true,
+      "dependencies": {
+        "text-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-wsl": {
@@ -1497,6 +1803,31 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ]
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -1567,6 +1898,18 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.5.0.tgz",
       "integrity": "sha512-wJkXvutRbNWcc37tt5j1HyOK1nosspdh3dj6LUYYAvF6JYNqs53IfRvK9oEpcwiDA1NdoIi64yAMfdivPeVAyw=="
+    },
+    "node_modules/meow": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -2091,6 +2434,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -2155,10 +2507,28 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/text-extensions": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
+      "integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "node_modules/titleize": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "@hidden-devs/discord-prompts.js",
   "description": "A simple library for creating state based prompts in discord.js",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
     "prepare": "npm run build",
     "preversion": "npm run lint",
-    "version": "npm run format && git add -A src",
-    "postversion": "git push && git push --tags",
+    "bump": "cliff-jumper",
+    "postbump": "git push && git push --tags",
+    "check-update": "cliff-jumper --dry-run",
     "build": "npm run format && tsc -p tsconfig.json",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint -c .eslintrc.cjs --ext .ts src"
@@ -19,6 +20,7 @@
     "README.md"
   ],
   "devDependencies": {
+    "@favware/cliff-jumper": "^2.2.3",
     "@typescript-eslint/eslint-plugin": "^6.12.0",
     "@typescript-eslint/parser": "^6.12.0",
     "eslint": "^8.54.0",

--- a/src/Prompt.ts
+++ b/src/Prompt.ts
@@ -4,8 +4,10 @@ import {
 	ButtonInteraction,
 	ComponentType,
 	InteractionCollector,
-	ModalBuilder,
+	InteractionReplyOptions,
+	ModalSubmitInteraction,
 	RepliableInteraction,
+	SnowflakeUtil,
 	StringSelectMenuBuilder,
 	StringSelectMenuInteraction,
 } from 'discord.js';
@@ -16,7 +18,6 @@ import {
 	PromptStateComponent,
 	PromptStateMessageCallback,
 } from './types/prompt.types';
-import { customId } from './util/customId';
 import { PromptError } from './util/errors';
 
 /**
@@ -34,9 +35,10 @@ export class Prompt<T extends object> {
 	private context: PromptContext<T>;
 
 	/** The current state */
-	private currentState?: PromptState<T> & {
-		components: (PromptStateComponent<T> & { customId: string; modal?: ModalBuilder })[];
-	};
+	private currentState?: PromptState<T>;
+
+	/** All components for this prompt */
+	private components: (PromptStateComponent<T> & { id: string })[] = [];
 
 	/** The interaction collector */
 	private collector?: InteractionCollector<ButtonInteraction | StringSelectMenuInteraction>;
@@ -63,35 +65,25 @@ export class Prompt<T extends object> {
 	/**
 	 * Starts the prompt with a given interaction
 	 * @param interaction The interaction starting off the sequence
+	 * @returns {boolean} If true, the prompt started successfully
 	 */
-	public async start(interaction: RepliableInteraction): Promise<void> {
+	public async start(interaction: RepliableInteraction): Promise<boolean> {
 		this.context.interaction = interaction;
 
-		await this.changeState(this.initialState, interaction);
+		return this.changeState(this.initialState, interaction);
 	}
 
-	private async changeState(newState: string, interaction: RepliableInteraction) {
+	private async changeState(newState: string, interaction: RepliableInteraction): Promise<boolean> {
 		const state = this.states.get(newState);
 		if (!state) return Promise.reject(new PromptError(`State ${newState} not found.`));
 
 		this.context.previousStates.push(this.currentState?.name ?? this.initialState);
-		this.currentState = { ...state, components: [] };
+		this.currentState = state;
 
 		const shouldChangeState = await state.onEntered?.(this.context);
-		if (shouldChangeState) this.changeState(shouldChangeState, interaction);
+		if (shouldChangeState) return this.changeState(shouldChangeState, interaction);
 
-		const messageData = await state.message(this.context);
-		const components = await this.formatComponents(messageData);
-		const messageOptions = {
-			components,
-			fetchReply: true,
-			ephemeral: messageData.ephemeral,
-			content:
-				typeof messageData.content === 'function'
-					? await messageData.content?.(this.context)
-					: messageData.content,
-			embeds: Array.isArray(messageData.embeds) ? messageData.embeds : await messageData.embeds(this.context),
-		};
+		const messageOptions = await this.prepareMessageOptions(state);
 
 		const msg =
 			interaction.replied || interaction.deferred
@@ -106,48 +98,48 @@ export class Prompt<T extends object> {
 		});
 
 		this.collector.on('collect', this.handleCollect.bind(this));
+
+		return true;
 	}
 
-	private async handleCollect(interaction: ButtonInteraction | StringSelectMenuInteraction) {
+	private async handleCollect(interaction: ButtonInteraction | StringSelectMenuInteraction): Promise<void> {
 		this.context.interaction = interaction;
 
-		const component = this.currentState?.components.find((c) => c.customId === interaction.customId);
+		const component = this.components.find((c) => c.id === interaction.customId);
 		if (!component) throw new PromptError(`Couldn't find component with customId: ${interaction.customId}`);
-
-		if (component.type === PromptComponentType.ModalSelectMenu) {
-			const shouldShowModal =
-				typeof component.showModal === 'boolean'
-					? component.showModal
-					: (await component.showModal?.(this.context as PromptContext<T, StringSelectMenuInteraction>)) ??
-					  true;
-
-			if (!shouldShowModal) {
-				await interaction.deferUpdate();
-
-				this.collector?.stop();
-
-				const newState =
-					typeof component.callback === 'string'
-						? component.callback
-						: await component.callback(this.context as PromptContext<T, StringSelectMenuInteraction>, null);
-				if (!newState) return interaction.deleteReply();
-
-				return this.changeState(newState, interaction);
-			}
-		}
 
 		if (
 			component.type === PromptComponentType.ModalButton ||
 			component.type === PromptComponentType.ModalSelectMenu
 		) {
-			const modal = component.modal!;
+			const childComponents =
+				typeof component.component === 'function'
+					? await component.component(this.context)
+					: component.component;
+			const modal =
+				typeof childComponents.modal === 'function'
+					? await childComponents.modal(interaction as never) // temporary
+					: childComponents.modal;
+
+			if (!modal) {
+				await interaction.deferUpdate();
+
+				this.collector?.stop();
+
+				const newState = await this.getNewStateFromCallback(component);
+				if (!newState) return interaction.deleteReply();
+
+				return void this.changeState(newState, interaction);
+			}
+
+			modal.setCustomId(component.id);
 
 			await interaction.showModal(modal);
 
 			const response = await interaction
 				.awaitModalSubmit({
 					time: 300000,
-					filter: (i) => i.user.id === interaction.user.id && i.customId === component.customId,
+					filter: (i) => i.user.id === interaction.user.id && i.customId === component.id,
 				})
 				.catch(() => null);
 
@@ -157,57 +149,88 @@ export class Prompt<T extends object> {
 
 			this.collector?.stop();
 
-			const newState =
-				typeof component?.callback === 'string'
-					? component.callback
-					: await component?.callback(
-							this.context as PromptContext<T, StringSelectMenuInteraction> &
-								PromptContext<T, ButtonInteraction>,
-							response,
-					  );
+			const newState = await this.getNewStateFromCallback(component, response);
 			if (!newState) return interaction.deleteReply();
 
-			return this.changeState(newState, interaction);
+			return void this.changeState(newState, interaction);
 		}
 
 		await interaction.deferUpdate();
 
 		this.collector?.stop();
 
-		const newState =
-			typeof component?.callback === 'string'
-				? component.callback
-				: await component?.callback(
-						this.context as PromptContext<T, StringSelectMenuInteraction> &
-							PromptContext<T, ButtonInteraction>,
-				  );
-
+		const newState = await this.getNewStateFromCallback(component);
 		if (!newState) return interaction.deleteReply();
 
-		await this.changeState(newState, interaction);
+		return void this.changeState(newState, interaction);
 	}
 
-	private async formatComponents(data: PromptStateMessageCallback<T>) {
-		const rows = [];
+	private async prepareMessageOptions(state: PromptState<T>): Promise<InteractionReplyOptions> {
+		const messageData = typeof state.message === 'object' ? state.message : await state.message(this.context);
+		const components = await this.formatComponents(messageData);
+		const messageOptions = {
+			components,
+			fetchReply: true,
+			ephemeral: messageData.ephemeral,
+			content:
+				typeof messageData.content === 'function'
+					? await messageData.content?.(this.context)
+					: messageData.content,
+			embeds: Array.isArray(messageData.embeds) ? messageData.embeds : await messageData.embeds(this.context),
+		};
 
-		for (const row of data.components) {
+		return messageOptions;
+	}
+
+	private async getNewStateFromCallback(
+		component: PromptStateComponent<T>,
+		modalInteraction?: ModalSubmitInteraction,
+	): Promise<string | undefined> {
+		if (typeof component.callback === 'string') return component.callback;
+
+		if (
+			component.type === PromptComponentType.ModalButton ||
+			component.type == PromptComponentType.ModalSelectMenu
+		) {
+			if (!modalInteraction) throw new PromptError('No modal submit interaction found when required.');
+
+			return component.callback(
+				this.context as PromptContext<T, StringSelectMenuInteraction> & PromptContext<T, ButtonInteraction>,
+				modalInteraction,
+			);
+		} else {
+			return component.callback(
+				this.context as PromptContext<T, StringSelectMenuInteraction> & PromptContext<T, ButtonInteraction>,
+			);
+		}
+	}
+
+	private async formatComponents(
+		data: PromptStateMessageCallback<T>,
+	): Promise<ActionRowBuilder<StringSelectMenuBuilder | ButtonBuilder>[]> {
+		const rows = [];
+		const components = Array.isArray(data.components) ? data.components : await data.components(this.context);
+
+		for (const row of components) {
 			const actionRow = new ActionRowBuilder<ButtonBuilder | StringSelectMenuBuilder>();
 
 			for (const component of row) {
-				const builder = await component.component(this.context);
-				const id = customId(this.currentState?.name ?? 'default');
+				const builder =
+					typeof component.component === 'function'
+						? await component.component(this.context)
+						: component.component;
+				const id = SnowflakeUtil.generate().toString();
 
 				if ('button' in builder) {
 					builder.button.setCustomId(id);
-					builder.modal.setCustomId(id);
 
-					this.currentState?.components.push({ ...component, customId: id, modal: builder.modal });
+					this.components.push({ ...component, id });
 
 					actionRow.addComponents(builder.button);
 				} else {
 					builder.setCustomId(id);
 
-					this.currentState?.components.push({ ...component, customId: id });
+					this.components.push({ ...component, id });
 					actionRow.addComponents(builder);
 				}
 			}

--- a/src/types/prompt.types.ts
+++ b/src/types/prompt.types.ts
@@ -1,4 +1,5 @@
 import {
+	AnySelectMenuInteraction,
 	ButtonBuilder,
 	ButtonInteraction,
 	EmbedBuilder,
@@ -31,11 +32,16 @@ export type PromptContext<Context extends object, T = RepliableInteraction> = Co
 
 // * Prompt Component Types * //
 
-interface PromptStateComponentBase<Context extends object, Interaction = RepliableInteraction> {
+interface ModalComponentReturnType<T, Interaction> {
+	button: T;
+	modal: ModalBuilder | ((interaction: Interaction) => MaybePromise<ModalBuilder | null>);
+}
+
+export interface PromptStateComponentBase<Context extends object, Interaction = RepliableInteraction> {
 	callback: string | ((ctx: PromptContext<Context, Interaction>) => MaybePromise<string | undefined>);
 }
 
-interface PromptStateComponentBaseWithInteraction<
+export interface PromptStateComponentBaseWithInteraction<
 	Context extends object,
 	Interaction = RepliableInteraction,
 	AlternateInteraction = Interaction,
@@ -51,29 +57,34 @@ interface PromptStateComponentBaseWithInteraction<
 /** A prompt state that uses a button component */
 export interface PromptStateButtonComponent<T extends object> extends PromptStateComponentBase<T, ButtonInteraction> {
 	type: PromptComponentType.Button;
-	component: (ctx: PromptContext<T>) => MaybePromise<ButtonBuilder>;
+	component: ButtonBuilder | ((ctx: PromptContext<T>) => MaybePromise<ButtonBuilder>);
 }
 
 /** A prompt state that contains a select menu */
 export interface PromptStateSelectMenuComponent<T extends object>
-	extends PromptStateComponentBase<T, StringSelectMenuInteraction> {
+	extends PromptStateComponentBase<T, AnySelectMenuInteraction> {
 	type: PromptComponentType.SelectMenu;
-	component: (ctx: PromptContext<T>) => MaybePromise<StringSelectMenuBuilder>;
+	component: StringSelectMenuBuilder | ((ctx: PromptContext<T>) => MaybePromise<StringSelectMenuBuilder>);
 }
 
 /** A prompt state that uses a modal that is opened by a button */
 export interface PromptStateModalButtonComponent<T extends object>
 	extends PromptStateComponentBaseWithInteraction<T, ButtonInteraction, ModalSubmitInteraction> {
 	type: PromptComponentType.ModalButton;
-	component: (ctx: PromptContext<T>) => MaybePromise<{ button: ButtonBuilder; modal: ModalBuilder }>;
+	component:
+		| ModalComponentReturnType<ButtonBuilder, ButtonInteraction>
+		| ((ctx: PromptContext<T>) => MaybePromise<ModalComponentReturnType<ButtonBuilder, ButtonInteraction>>);
 }
 
 /** A prompt state that is a modal opened by a select menu component */
 export interface PromptStateModalSelectMenuComponent<T extends object>
 	extends PromptStateComponentBaseWithInteraction<T, StringSelectMenuInteraction, ModalSubmitInteraction | null> {
 	type: PromptComponentType.ModalSelectMenu;
-	showModal?: boolean | ((ctx: PromptContext<T, StringSelectMenuInteraction>) => MaybePromise<boolean>);
-	component: (ctx: PromptContext<T>) => MaybePromise<{ button: StringSelectMenuBuilder; modal: ModalBuilder }>;
+	component:
+		| ModalComponentReturnType<StringSelectMenuBuilder, StringSelectMenuInteraction>
+		| ((
+				ctx: PromptContext<T>,
+		  ) => MaybePromise<ModalComponentReturnType<StringSelectMenuBuilder, StringSelectMenuInteraction>>);
 }
 
 /** A type representing a prompt state component, used when defining the components added for a prompt state */
@@ -90,7 +101,7 @@ export interface PromptStateMessageCallback<T extends object> {
 	ephemeral: boolean;
 	content?: string | ((ctx: PromptContext<T>) => MaybePromise<string | undefined>);
 	embeds: EmbedBuilder[] | ((ctx: PromptContext<T>) => MaybePromise<EmbedBuilder[]>);
-	components: PromptStateComponent<T>[][];
+	components: PromptStateComponent<T>[][] | ((ctx: PromptContext<T>) => MaybePromise<PromptStateComponent<T>[][]>);
 }
 
 /**
@@ -101,5 +112,5 @@ export interface PromptState<T extends object> {
 	name: string;
 	timeout?: number;
 	onEntered?: (ctx: PromptContext<T>) => MaybePromise<string | undefined>;
-	message: (ctx: PromptContext<T>) => MaybePromise<PromptStateMessageCallback<T>>;
+	message: PromptStateMessageCallback<T> | ((ctx: PromptContext<T>) => MaybePromise<PromptStateMessageCallback<T>>);
 }

--- a/src/types/prompt.types.ts
+++ b/src/types/prompt.types.ts
@@ -1,5 +1,4 @@
 import {
-	AnySelectMenuInteraction,
 	ButtonBuilder,
 	ButtonInteraction,
 	EmbedBuilder,
@@ -62,7 +61,7 @@ export interface PromptStateButtonComponent<T extends object> extends PromptStat
 
 /** A prompt state that contains a select menu */
 export interface PromptStateSelectMenuComponent<T extends object>
-	extends PromptStateComponentBase<T, AnySelectMenuInteraction> {
+	extends PromptStateComponentBase<T, StringSelectMenuBuilder> {
 	type: PromptComponentType.SelectMenu;
 	component: StringSelectMenuBuilder | ((ctx: PromptContext<T>) => MaybePromise<StringSelectMenuBuilder>);
 }

--- a/src/types/prompt.types.ts
+++ b/src/types/prompt.types.ts
@@ -61,7 +61,7 @@ export interface PromptStateButtonComponent<T extends object> extends PromptStat
 
 /** A prompt state that contains a select menu */
 export interface PromptStateSelectMenuComponent<T extends object>
-	extends PromptStateComponentBase<T, StringSelectMenuBuilder> {
+	extends PromptStateComponentBase<T, StringSelectMenuInteraction> {
 	type: PromptComponentType.SelectMenu;
 	component: StringSelectMenuBuilder | ((ctx: PromptContext<T>) => MaybePromise<StringSelectMenuBuilder>);
 }


### PR DESCRIPTION
# Refactor

- Made some changes to the main code for better readability.
- Removed `showModal` option in favor of returning null in `component.modal` function.

# Additions
- Added [cliff-jumper](https://github.com/favware/cliff-jumper), which should improve workflow and make versioning easier.
- When publishing the package, follow these steps:
  - Push the changes/merge a pull request to the main branch.
  - Run `npm run bump` to bump the version based on the commit history. Reference: [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - It should automatically bump the version and push the changes to github by running `git push && git push --tags`, if it does not then do that.
  - Run the `package-deploy` workflow from the actions tab.